### PR TITLE
Adding array function to Literals

### DIFF
--- a/src/main/java/org/javafunk/funk/Literals.java
+++ b/src/main/java/org/javafunk/funk/Literals.java
@@ -19,6 +19,17 @@ import static java.util.Arrays.asList;
 public class Literals {
     private Literals() {}
 
+    /**
+     * Older APIs are sometimes written to accept arrays of objects as arguments in cases where we'd like to use varargs.
+     *
+     * @param elements The elements we'd like to convert to an array.
+     *
+     * @return The given elements as an array.
+     */
+    public static <E> E[] array(E... elements) {
+        return elements;
+    }
+
     public static <E> Iterable<E> iterable() {
         return new IterableBuilder<E>().build();
     }

--- a/src/test/java/org/javafunk/funk/LiteralsTest.java
+++ b/src/test/java/org/javafunk/funk/LiteralsTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
 import static org.javafunk.funk.Literals.*;
 import static org.javafunk.funk.builders.IterableBuilder.iterableBuilder;
 import static org.javafunk.funk.matchers.IteratorMatchers.isIteratorWithSameElementsAs;
@@ -32,6 +33,16 @@ import static org.javafunk.funk.testclasses.Location.location;
 import static org.javafunk.funk.testclasses.Name.name;
 
 public class LiteralsTest {
+    @Test
+    public void shouldReturnVaragsAsArray() {
+        Object one = new Object();
+        Object two = new Object();
+
+        Object[] actual = array(one, two);
+
+        assertThat(actual, arrayContaining(one, two));
+    }
+
     @Test
     public void shouldReturnAnEmptyIterable() throws Exception {
         // Given


### PR DESCRIPTION
Older APIs are sometimes written to accept arrays of objects as arguments in cases where we'd like to use varargs.
